### PR TITLE
Readme expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Make sure you have them properly installed before running the code.
 
 # Running and Developing CAETÊ
 ~This section suposses you have a working python environment and an installed fortran compiler.
-If you need help setting up your invornment, check the [development environment section](#development-Environment)
+If you need help setting up your environment, check the [development environment section](#development-Environment)
 
 CAETÊ uses both Python and Fortran and uses `f2py` module to create an interface between them. This means that the Fortran code must be compiled before you can run Python code.
 
@@ -49,7 +49,7 @@ python model_driver.py
 You can also run it interactively inside `ipython` to have direct access to the variables or you can also run it directly from the vscode debug environment.
 
 # Development Environment
-If you need help configuring your development environment, installing python, installing CAETÊ dependencies or setting up a debug enviornment in vscode, check the [CAETÊ starting packtutorial](https://github.com/fmammoli/CAETE-Tutorials)
+If you need help configuring your development environment, installing python, installing CAETÊ dependencies or setting up a debug enviornment in vscode, check the [CAETÊ starting pack tutorial](https://github.com/fmammoli/CAETE-Tutorials)
 
 ## __AUTHORS__:
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,52 @@ The code in this repository is based on an earlier version of CAETÊ that was no
 
 THis is part of my ongoing PhD research project.
 
+# Development Dependencies
+CAETÊ depends on a few packages that must be installed beforehand.
+You can installed them using your favorite package manager: `apt`, `brew`, `pip`, `poetry`, etc.
+
+General Dependencies
+- make (for building automation)
+
+Python Dependencies
+- numpy
+- f2py (part of numpy)
+- cftime
+- pandas
+- matplotlib
+- ipython
+
+Make sure you have them properly installed before running the code.
+
+# Running and Developing CAETÊ
+~This section suposses you have a working python environment and an installed fortran compiler.
+If you need help setting up your invornment, check the [development environment section](#development-Environment)
+
+CAETÊ uses both Python and Fortran and uses `f2py` module to create an interface between them. This means that the Fortran code must be compiled before you can run Python code.
+
+The Makefile inside `/src` folder have useful automation to make it easier.
+
+`make clean` - it clear your python cache, deletes the `/output` folder and deletes all compiled fortran files, including the `.pyf` file.
+
+`make so` - compiles all fortran code and creates the `caete_module.pyf`, the interface between Fortran and Python code.
+
+To run CAETÊ you can do the following:
+```bash
+# Clean you cache
+make clean
+
+# Build caete_module.pyf
+make so
+
+# Run the model
+python model_driver.py
+```
+
+You can also run it interactively inside `ipython` to have direct access to the variables or you can also run it directly from the vscode debug environment.
+
+# Development Environment
+If you need help configuring your development environment, installing python, installing CAETÊ dependencies or setting up a debug enviornment in vscode, check the [CAETÊ starting packtutorial](https://github.com/fmammoli/CAETE-Tutorials)
+
 ## __AUTHORS__:
 
  - Bianca Rius


### PR DESCRIPTION
Pequeno incremento ao README.md.
Também linkei um tutorial que eu fiz para instalar um ambiente python para rodar o CAETÊ, é basicamente os passos que eu segui. Pode ser útil para pessoas novas do LabTerra que ainda não tem um ambiente de desenvolvimento instalado ou pra quem está com problemas no ambiente.
Fiz uma configuração para debugar o modelo linha por linha pelo vscode no tutorial tbm, ficou bem prático pra entender o fluxo das coisas.
Se você ou o Caio quiserem dar uma olhada, [https://github.com/fmammoli/CAETE-Tutorials](https://github.com/fmammoli/CAETE-Tutorials)
